### PR TITLE
Resource caching and worker limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add cache for resources to prevent calls to the LINSTOR API for every deployed resource.
+
 ## [1.0.2] - 2024-07-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Limit number of parallel reconciliations with `--workers` parameter, defaulting to 10.
+
 ### Changed
 - Add cache for resources to prevent calls to the LINSTOR API for every deployed resource.
 

--- a/cmd/linstor-affinity-controller/main.go
+++ b/cmd/linstor-affinity-controller/main.go
@@ -19,6 +19,7 @@ func NewControllerCommand() *cobra.Command {
 	var reconcileRate, resyncRate, timeout time.Duration
 	var electorCfg leaderelection.Config
 	var bindAddress, propertyNamespace string
+	var workers int
 
 	cmd := &cobra.Command{
 		Use:     "linstor-volume-controller",
@@ -45,6 +46,7 @@ func NewControllerCommand() *cobra.Command {
 				LeaderElector:     elector,
 				BindAddress:       bindAddress,
 				PropertyNamespace: propertyNamespace,
+				Workers:           workers,
 			})
 			if err != nil {
 				return err
@@ -60,6 +62,7 @@ func NewControllerCommand() *cobra.Command {
 	cmd.Flags().DurationVar(&timeout, "timeout", 1*time.Minute, "how long a single reconcile attempt can take")
 	cmd.Flags().StringVar(&bindAddress, "bind-address", "[::]:8000", "the address to use for /healthz and /readyz probes")
 	cmd.Flags().StringVar(&propertyNamespace, "property-namespace", "", "The property namespace used by LINSTOR CSI")
+	cmd.Flags().IntVar(&workers, "workers", 10, "Number of reconciliations to run in parallel")
 	electorCfg.AddFlags(cmd.Flags())
 
 	return cmd

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -152,6 +152,11 @@ func (a *AffinityReconciler) Run(ctx context.Context) error {
 			eg.Go(func() error {
 				pvs, _ := a.pvIndexer.GetIndexer().ByIndex("rd", resource.Name)
 
+				// There should be one PV in the normal case, but there may be zero in these cases:
+				// * The resource is not actually related to Kubernetes and managed externally
+				// * The resource was updated by our reconciler, but the reconciler did not complete for one reason or
+				//   another, so we need to continue to restore the PV.
+				// reconcileOne() can deal with a "nil" PV.
 				var pv *corev1.PersistentVolume
 				if len(pvs) == 1 {
 					pv = pvs[0].(*corev1.PersistentVolume)


### PR DESCRIPTION
* Add a cache for the LINSTOR API, otherwise every resource definition might trigger a call to the LINSTOR API
* Add `--workers` option to limit the number of reconciliations to run in parallel.