### PR TITLE
add override annotations to PVs for access context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `override.piraeus.io` annotations to PVs to override access context.
+
 ## [1.2.0] - 2025-06-27
 
 ### Added

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -249,7 +249,7 @@ func (a *AffinityController) Run(ctx context.Context) error {
 				}
 
 				err := op.Execute(runCtx)
-				if err != nil {
+				if err != nil && operationFailCounter != nil {
 					operationFailCounter.WithLabelValues(op.Name).Inc()
 				}
 

--- a/pkg/version/consts.go
+++ b/pkg/version/consts.go
@@ -3,5 +3,6 @@ package version
 import linstor "github.com/LINBIT/golinstor"
 
 const (
-	SavedPVPropKey = linstor.NamespcAuxiliary + "/affinity-updater-saved-pv"
+	SavedPVPropKey           = linstor.NamespcAuxiliary + "/affinity-updater-saved-pv"
+	OverrideAnnotationPrefix = "override.piraeus.io"
 )


### PR DESCRIPTION
Using annotations starting with 'override.piraeus.io' overrides the existing access context for a PV. This can be used to (temporarily) let PVs be rescheduled without having to make permanent changes on the LINSTOR side.

This is useful in evacuation cases: Kubernetes can reschedule Pods before we start the LINSTOR evacuation, leading LINSTOR to place the replacement resource on the node the workload already runs on (if possible).