### PR TITLE
add the option to skip reconiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ The following options can be set on the chart:
 | `autoscaling.enabled`         | Enable creation of a horizontal pod autoscaler to ensure availability in case of high usage` | `"false`                                                      |
 | `monitoring.enabled`          | Enable creation of resources for monitoring via Prometheus Operator                          | `"false"`                                                     |
 
+## Volume annotations and LINSTOR properties
+
+The controller's behaviour for individual volumes can be controlled via Kubernetes annotations on the PV and LINSTOR
+properties on the ResourceDefinition (RD).
+
+### Skipping reconciliation
+
+Setting the annotation `piraeus.io/skip-affinity-controller` to any non-empty value on a PV prevents the controller
+from replacing that PV, leaving its affinity unchanged:
+
+```
+kubectl annotate pv <pv-name> piraeus.io/skip-affinity-controller=true
+```
+
+The same effect can be achieved from the LINSTOR side by setting the auxiliary property
+`Aux/affinity-updater-skip` on the ResourceDefinition:
+
+```
+linstor rd set-property <rd-name> Aux/affinity-updater-skip true
+```
+
+### Overriding the remote access policy
+
+By default the controller derives the remote access policy from the StorageClass parameters or CSI volume context.
+To override it for a specific volume, set an annotation whose key starts with `override.piraeus.io` on the PV.
+The value must be a valid remote access policy string as understood by linstor-csi.
+
 ***
 
 [^1]: That is not 100% true: you can _add_ affinity if it was previously unset, but once set, it can't be modified.

--- a/pkg/controller/affinity.go
+++ b/pkg/controller/affinity.go
@@ -74,6 +74,11 @@ func (a *AffinityReconciler) GenerateOperations(ctx context.Context, now time.Ti
 }
 
 func (a *AffinityReconciler) generateOperations(ctx context.Context, rd *client.ResourceDefinition, pv *corev1.PersistentVolume, now time.Time) (*operations.Operation, error) {
+	if rd.Props[version.SkipPropKey] != "" {
+		klog.V(2).Infof("Skipping reconciliation of RD '%s' because of LINSTOR property '%s'", rd.Name, version.SkipPropKey)
+		return nil, nil
+	}
+
 	needsApply := false
 	rawSavedProp, hasSavedProp := rd.Props[version.SavedPVPropKey]
 
@@ -111,6 +116,11 @@ func (a *AffinityReconciler) generateOperations(ctx context.Context, rd *client.
 			klog.V(2).Infof("Need to remove stale PV property from RD")
 			return operations.RemovePVProperty(a.LinstorClient, rd.Name), nil
 		}
+	}
+
+	if pv.Annotations[version.SkipAnnotation] != "" {
+		klog.V(2).Infof("Skipping reconciliation of PV '%s' because of annotation '%s'", pv.Name, version.SkipAnnotation)
+		return nil, nil
 	}
 
 	if pv.Spec.CSI == nil {

--- a/pkg/version/consts.go
+++ b/pkg/version/consts.go
@@ -4,5 +4,7 @@ import linstor "github.com/LINBIT/golinstor"
 
 const (
 	SavedPVPropKey           = linstor.NamespcAuxiliary + "/affinity-updater-saved-pv"
+	SkipPropKey              = linstor.NamespcAuxiliary + "/affinity-updater-skip"
 	OverrideAnnotationPrefix = "override.piraeus.io"
+	SkipAnnotation           = "piraeus.io/skip-affinity-controller"
 )


### PR DESCRIPTION
Sometimes a user might want to mess with placement of a volume without interrupting the workload. This is now possible using either an annotation on the PV, or by setting a property on the RD.